### PR TITLE
Fix pkg name to fix registry sync

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -306,8 +306,8 @@
 	"branch": "v0.9.1"
     },
     {
-	"package": "vip",
-	"url": "https://github.com/mrc-ide/vip",
+	"package": "popim",
+	"url": "https://github.com/mrc-ide/popim",
 	"branch": "main"
     },
     {


### PR DESCRIPTION
r-universe registry udpate fails with the following error message:

> ERROR Package 'vip' from registry does not match package name in description file: 'popim' 
No packages to delete. Everything is up-to-date

https://github.com/r-universe/mrc-ide/actions/workflows/sync.yml