### PR TITLE
Fix branch names.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -277,7 +277,7 @@
     {
 	"package": "cinterpolate",
 	"url": "https://github.com/mrc-ide/cinterpolate",
-	"branch": "main"
+	"branch": "master"
     },
     {
 	"package": "hipercow",
@@ -313,6 +313,6 @@
     {
         "package": "dqrng",
         "url": "https://github.com/daqana/dqrng",
-        "branch": "master"
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
Two packages had mismatching branch names (main vs master). This was causing problems during the r-universe sync.

I think dqrng renamed their branch from master to main. I don't think cinterpolate ever worked (it's not visible on the r-universe).